### PR TITLE
[주문 내역, 서버 :: 주문 내역 이벤트 핸들링 수정 및 백엔드 연동]

### DIFF
--- a/server/routers/MyPageRouter.js
+++ b/server/routers/MyPageRouter.js
@@ -2,7 +2,7 @@ const express = require("express");
 const router = express.Router();
 
 const myPageRouter = (db) => {
-    router.get("/load/:id", async (req, res) => {
+    router.get("/loadInfo/:id", async (req, res) => {
         const {id} = req.params;
 
         await db.collection("user").find({"id": id}).forEach((r) => {
@@ -10,12 +10,27 @@ const myPageRouter = (db) => {
         })
     })
 
-    router.post("/update", async (req, res) => {
-        db.collection("user").updateOne({id: req.body.id}, {$set:{address: req.body.address, detailed_address: req.body.detailed_address}}).then(() => {
+    router.get("/loadOrderHistory/:id", async (req, res) => {
+        const result = [];
+        const {id} = req.params;
+
+        await db.collection("orderHistory").find({"userID": id}).sort({"date": 1}).forEach((r) => {
+            result.push(r);
+        })
+
+        return res.json(result);
+    })
+
+    router.post("/userUpdate", async (req, res) => {
+        await db.collection("user").updateOne({id: req.body.id}, {$set:{address: req.body.address, detailed_address: req.body.detailed_address}}).then(() => {
             console.log("유저 업데이트 성공");
         });
+    })
 
-        return res.json(req.body);
+    router.post("/reviewInsert", async (req, res) => {
+        await db.collection("review").insertOne({...req.body}).then(() => {
+            console.log("리뷰 등록 성공");
+        });
     })
 
     return router;

--- a/server/routers/OwnerPageRouter.js
+++ b/server/routers/OwnerPageRouter.js
@@ -14,7 +14,7 @@ const ownerPageRouter = (form_data, db) => {
         });
 
         const amounts = [];
-        await db.collection("orderHistory").find({"ownerNumber": "1"}).sort({"menu": 1}).forEach((r) => {
+        await db.collection("orderHistory").find({"ownerID": "ownerID"}).sort({"menu": 1}).forEach((r) => {
             idx = amounts[idx] === undefined ? idx + 1 : idx;
             amounts.splice(idx, 0, amounts[idx] ? amounts[idx] + 1 : 1);
         });
@@ -22,7 +22,7 @@ const ownerPageRouter = (form_data, db) => {
         idx = 0;
         const sales = [];
         const dayOfTheWeek = [];
-        await db.collection("orderHistory").find({"ownerNumber": "1"}).sort({"date": 1}).forEach((r) => {
+        await db.collection("orderHistory").find({"ownerID": "ownerID"}).sort({"date": 1}).forEach((r) => {
             if (idx !== 0) {
                 if (dayOfTheWeek[idx - 1] !== r.date) {
                     dayOfTheWeek[idx] = r.date;
@@ -45,7 +45,6 @@ const ownerPageRouter = (form_data, db) => {
         db.collection("pizza").insertOne({...req.body, img: req.file}).then(() => {
             console.log("데이터 삽입 성공");
         });
-        return res.json(req.body);
     })
 
     /*router.post("/tempDummyInsert", form_data.any(), (req, res) => {
@@ -53,7 +52,6 @@ const ownerPageRouter = (form_data, db) => {
     db.collection("orderHistory").insertOne(req.body).then(() => {
         console.log("데이터 삽입 성공");
     });
-    return res.json(req.body);
 })*/
 
     return router;

--- a/src/components/my_page/MyPage.js
+++ b/src/components/my_page/MyPage.js
@@ -3,20 +3,16 @@ import TitleHeaderLayout from "./info_modify/TitleHeaderLayout";
 import ShoppingHeader from "../shopping_basket/ShoppingHeader";
 import "../my_page/info_modify/TitleHeaderLayout.css";
 import "../my_page/info_modify/InfoModify.css"
-//import OrderListTab from "./OrderListTab";
+import OrderListTab from "./OrderListTab";
 
 function MyPage() {
-    const [visiable, setVisiable] = useState(false);
-    const clickBtn = () => {
-        setVisiable(!visiable);
-    }
     return (
         <div>
             <ShoppingHeader></ShoppingHeader>
             <div className="my-page-inside">
                 <div className="my-page-header">마이페이지</div>
                 <TitleHeaderLayout></TitleHeaderLayout>
-                {/*<OrderListTab clickBtn={clickBtn} visiable={visiable}></OrderListTab>*/}
+                <OrderListTab/>
             </div>
         </div>
     )

--- a/src/components/my_page/OrderListElement.js
+++ b/src/components/my_page/OrderListElement.js
@@ -1,0 +1,74 @@
+import img from "../shopping_basket/img/expert1.png";
+import {useState} from "react";
+import axios from "axios";
+
+const minusBtnImg = "data:image/svg+xml;base64,PHN2ZyBpZD0iXy0iIGRhdGEtbmFtZT0iLSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA2MCA2MCI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogI2NjYzsKICAgICAgfQoKICAgICAgLmNscy0yIHsKICAgICAgICBmaWxsOiAjZmZmOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8Y2lyY2xlIGNsYXNzPSJjbHMtMSIgY3g9IjMwIiBjeT0iMzAiIHI9IjMwIi8+CiAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIxOCIgeT0iMjkiIHdpZHRoPSIyNSIgaGVpZ2h0PSIzIi8+Cjwvc3ZnPgo="
+const plusBtnImg = "data:image/svg+xml;base64,PHN2ZyBpZD0iXyIgZGF0YS1uYW1lPSIrIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MiIgaGVpZ2h0PSI2MiIgdmlld0JveD0iMCAwIDYyIDYyIj4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmNscy0xIHsKICAgICAgICBmaWxsOiAjZmZmOwogICAgICAgIHN0cm9rZTogIzQxYjZlNjsKICAgICAgICBzdHJva2Utd2lkdGg6IDJweDsKICAgICAgfQoKICAgICAgLmNscy0yLCAuY2xzLTMgewogICAgICAgIGZpbGw6ICM0MWI2ZTY7CiAgICAgIH0KCiAgICAgIC5jbHMtMiB7CiAgICAgICAgZmlsbC1ydWxlOiBldmVub2RkOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8Y2lyY2xlIGNsYXNzPSJjbHMtMSIgY3g9IjMxIiBjeT0iMzEiIHI9IjMwIi8+CiAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJNNjI4LDg2N2gyNXYzSDYyOHYtM1ptMTEtMTFoM3YyNWgtM1Y4NTZaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtNjA5IC04MzcpIi8+CiAgPHJlY3QgaWQ9IuyCrOqwge2YlV8yIiBkYXRhLW5hbWU9IuyCrOqwge2YlSAyIiBjbGFzcz0iY2xzLTMiIHg9IjMwIiB5PSIzMCIgd2lkdGg9IjMiIGhlaWdodD0iMyIvPgo8L3N2Zz4K"
+
+
+function OrderListElement({element}) {
+    const [visible, setVisible] = useState(false);
+    const [number, setNumber] = useState(1);
+    const [opinion, setOpinion] = useState("");
+    const clickBtn = () => {
+        setVisible(!visible);
+    }
+    const clickPlusBtn = () => {
+        if(number < 5) {
+            setNumber(number+ 1);
+        }
+    }
+    const clickMinusBtn = () => {
+        if(number > 1) {
+            setNumber(number- 1);
+        }
+    }
+
+    const submit = () => {
+        axios.post("http://localhost:4000/myPage/reviewInsert", {
+            orderHistoryNumber: element.orderHistoryNumber,
+            text: opinion
+        }).then(r => (console.log(r)));
+
+        setOpinion("");
+        setVisible(!visible);
+    }
+
+    return(
+        <div className="myOrder">
+            <div className="show">
+                <span className="info">주문 일자</span>
+                <span className="orderDate">{element.date}</span>
+            </div>
+            <div className="show">
+                <span className="info">주문 메뉴</span>
+                <span className="orderMenu">{element.menu}</span>
+            </div>
+            <div className="show">
+                <span className="info">결제금액</span>
+                <span className="orderPrice">{element.price}원</span>
+            </div>
+            <div className="show">
+                <span className="info">배달지정보</span>
+                <span className="orderAddress">{element.dest}</span>
+            </div>
+            <div className="show">
+                <span className="info">주문 매장</span>
+                <span className="orderStore">{element.store + "(" + element.storePhoneNumber + ")"}</span>
+            </div>
+            <div className="ReviewBtn" onClick={clickBtn}>후기 작성</div>
+            {visible ? <div className="myReview">
+                <div className="myScore">
+                    <img src={minusBtnImg} className="minusBtn" onClick={clickMinusBtn}></img>
+                    <span className="score">{number}</span>
+                    <img src={plusBtnImg} className="plusBtn" onClick={clickPlusBtn}></img>
+                </div>
+                <h3>리뷰 작성하세요</h3>
+                <input className="myOpinion" value={opinion} onChange={(e) => {setOpinion(e.target.value);}}></input>
+                <div className="ReviewBtn" onClick={submit}>등록</div>
+            </div> : <div/>}
+        </div>
+    )
+}
+
+export default OrderListElement;

--- a/src/components/my_page/OrderListTab.js
+++ b/src/components/my_page/OrderListTab.js
@@ -1,85 +1,23 @@
-import {Link} from "react-router-dom";
 import axios from "axios";
-import {useState} from "react";
-//import OrderListData from "./OrderListData";
+import {useEffect, useState} from "react";
 import "./OrderListTab.css"
-import img from "../shopping_basket/img/expert1.png";
+import OrderListElement from "./OrderListElement";
 
-const minusBtnImg = "data:image/svg+xml;base64,PHN2ZyBpZD0iXy0iIGRhdGEtbmFtZT0iLSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA2MCA2MCI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgZmlsbDogI2NjYzsKICAgICAgfQoKICAgICAgLmNscy0yIHsKICAgICAgICBmaWxsOiAjZmZmOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8Y2lyY2xlIGNsYXNzPSJjbHMtMSIgY3g9IjMwIiBjeT0iMzAiIHI9IjMwIi8+CiAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIxOCIgeT0iMjkiIHdpZHRoPSIyNSIgaGVpZ2h0PSIzIi8+Cjwvc3ZnPgo="
-const plusBtnImg = "data:image/svg+xml;base64,PHN2ZyBpZD0iXyIgZGF0YS1uYW1lPSIrIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MiIgaGVpZ2h0PSI2MiIgdmlld0JveD0iMCAwIDYyIDYyIj4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmNscy0xIHsKICAgICAgICBmaWxsOiAjZmZmOwogICAgICAgIHN0cm9rZTogIzQxYjZlNjsKICAgICAgICBzdHJva2Utd2lkdGg6IDJweDsKICAgICAgfQoKICAgICAgLmNscy0yLCAuY2xzLTMgewogICAgICAgIGZpbGw6ICM0MWI2ZTY7CiAgICAgIH0KCiAgICAgIC5jbHMtMiB7CiAgICAgICAgZmlsbC1ydWxlOiBldmVub2RkOwogICAgICB9CiAgICA8L3N0eWxlPgogIDwvZGVmcz4KICA8Y2lyY2xlIGNsYXNzPSJjbHMtMSIgY3g9IjMxIiBjeT0iMzEiIHI9IjMwIi8+CiAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJNNjI4LDg2N2gyNXYzSDYyOHYtM1ptMTEtMTFoM3YyNWgtM1Y4NTZaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtNjA5IC04MzcpIi8+CiAgPHJlY3QgaWQ9IuyCrOqwge2YlV8yIiBkYXRhLW5hbWU9IuyCrOqwge2YlSAyIiBjbGFzcz0iY2xzLTMiIHg9IjMwIiB5PSIzMCIgd2lkdGg9IjMiIGhlaWdodD0iMyIvPgo8L3N2Zz4K"
+function OrderListTab() {
+    const [myOrderList, setMyOrderList] = useState([]);
+    useEffect(() => {
+        axios.get("http://localhost:4000/myPage/loadOrderHistory/testID").then((r) => {
+            setMyOrderList(r.data);
+        });
+    }, []);
 
-function OrderListTab({clickBtn, visiable}) {
-    console.log(clickBtn)
-    console.log(visiable)
-    // let [myOrderList, setMyOrderList] = useState([]);
-    const [number, setNumber] = useState(1);
-    let testArray = []
-    testArray = OrderListData
-
-    const clickPlusBtn = () => {
-        if(number < 5) {
-            setNumber(number+ 1);
-        }
-    }
-    const clickMinusBtn = () => {
-        if(number > 1) {
-            setNumber(number- 1);
-        }
-    }
-
-    // const fetchData = async () => {
-    //     try {
-    //         axios.get("http://localhost:4000/myOrderList/test").then((res) => {
-    //                 setMyOrderList(res.data) //받은 주문내역 객체 배열로 저장
-    //         });
-    //     }catch (error) {
-    //         console.error("Error fetching data:", error);
-    //     }
-    // }
-
-    //DB에서 받아올 때는 testArray 말고 OrderList로 하면 됨
     return (
         <div className="orderList">
-            {testArray.map((testArray, index) => {
-                return (
-                    <div className="myOrder">
-                        <div className="show">
-                            <span className="info">주문 일자</span>
-                            <span className="orderDate">{testArray.orderDate}</span>
-                        </div>
-                        <div className="show">
-                            <span className="info">주문 메뉴</span>
-                            <span className="orderMenu">{testArray.orderMenu}</span>
-                        </div>
-                        <div className="show">
-                            <span className="info">결제금액</span>
-                            <span className="orderPrice">{testArray.price}원</span>
-                        </div>
-                        <div className="show">
-                            <span className="info">배달지정보</span>
-                            <span className="orderAddress">{testArray.address}</span>
-                        </div>
-                        <div className="show">
-                            <span className="info">주문 매장</span>
-                            <span className="orderStore">{testArray.store}</span>
-                        </div>
-                        <div className="ReviewBtn" onClick={clickBtn}>후기 작성</div>
-                        {visiable ? <div className="myReview">
-                            <div className="myScore">
-                                <img src={minusBtnImg} className="minusBtn" onClick={clickMinusBtn}></img>
-                                <span className="score">{number}</span>
-                                <img src={plusBtnImg} className="plusBtn" onClick={clickPlusBtn}></img>
-                            </div>
-                            <h3>리뷰 작성하세요</h3>
-                            <input className="myOpinion"></input>
-                            <div className="ReviewBtn">등록</div>
-                        </div> : <div/>}
-                    </div>
-                )
+            {myOrderList.map((element) => {
+                return (<OrderListElement element={element}/>)
             })}
         </div>
     );
 }
-
 
 export default OrderListTab;

--- a/src/components/my_page/info_modify/InfoModify.js
+++ b/src/components/my_page/info_modify/InfoModify.js
@@ -21,7 +21,7 @@ function InfoModify(){
     const [detailedAddress, setDetailedAddress] = useState("");
 
     const submit = () => {
-        axios.post("http://localhost:4000/myPage/update", {
+        axios.post("http://localhost:4000/myPage/userUpdate", {
             ...user,
             address: address,
             detailed_address: detailedAddress
@@ -30,7 +30,7 @@ function InfoModify(){
 
 
     useEffect(() => {
-        axios.get("http://localhost:4000/myPage/load/testID").then((r) => {
+        axios.get("http://localhost:4000/myPage/loadInfo/testID").then((r) => {
             const emailArr = r.data.email.split("@");
 
             setUser(r.data);

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <InfoModify/>
+      <MyPage/>
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## 작업 내용
1. 주문내역 이벤트 핸들링 수정
2. 주문내역 백엔드 연동

## 상세 내용
주문내역의 후기작성 버튼을 누르면 모든 요소의 후기작성 입력칸이 활성화되는 오류 수정
주문내역을 백엔드와 연동하여 이제 DB에서 주문내역을 불러오고 등록 버튼을 누르면 리뷰가 DB에 등록됨

※ 현재까지의 DB 컬렉션 구조 모음
![owner](https://github.com/winteeeee/wp_termproject/assets/102248077/f937bece-54ae-4b88-9d74-de5755236472)
![pizza](https://github.com/winteeeee/wp_termproject/assets/102248077/904afc95-9dc7-45de-853f-ff8646dc4d53)
![review](https://github.com/winteeeee/wp_termproject/assets/102248077/6a9414b8-bb36-4404-a0ae-08f13194e6ff)
![user](https://github.com/winteeeee/wp_termproject/assets/102248077/7e76ca67-b8d8-470e-8d9d-55ab0b6468b3)
![주문내역](https://github.com/winteeeee/wp_termproject/assets/102248077/192f4961-5780-41bd-925a-5544dbcd968b)
